### PR TITLE
IC-73 exclude unused protobuf-java dependency from tink to fix CVE-2021-22569

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,10 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % "3.2.2",
       "co.fs2" %% "fs2-io" % "3.2.2",
-      "com.google.crypto.tink" % "tink" % "1.6.1",
+      "com.google.crypto.tink" % "tink" % "1.6.1" excludeAll(
+        // excluded due to CVE in version used by tink 1.6.1 -> https://github.com/advisories/GHSA-wrvw-hg22-4m67
+        ExclusionRule(organization = "com.google.protobuf"),
+      ),
       "com.softwaremill.magnolia1_2" %% "magnolia" % "1.0.0-M7",
       "de.siegmar" % "fastcsv" % "1.0.3",
       "org.mapdb" % "mapdb" % "3.0.8",


### PR DESCRIPTION
The earliest fixed version for CVE-2021-22569 is in protobuf-java 3.16.1 but tink 1.6.1 uses [3.14.0](https://github.com/google/tink/blob/dca70f855d483d4350e222e2754db2f9e63c9ecb/maven/tink.pom.xml#L68)

Rather than force the dependency to a later version I have excluded it as it is not used.

https://github.com/advisories/GHSA-wrvw-hg22-4m67