### PR TITLE
PFM-684 Adds a partition attribute to the filter

### DIFF
--- a/src/main/scala/com/intenthq/action_processor/integrations/feeds/FeedContext.scala
+++ b/src/main/scala/com/intenthq/action_processor/integrations/feeds/FeedContext.scala
@@ -6,9 +6,9 @@ import com.intenthq.embeddings.Mapping
 
 import java.time.{LocalDate, LocalTime}
 
-case class FeedFilter(date: Option[LocalDate], time: Option[LocalTime])
+case class FeedFilter(date: Option[LocalDate], time: Option[LocalTime], partition: Map[String, String])
 object FeedFilter {
-  val empty: FeedFilter = FeedFilter(None, None)
+  val empty: FeedFilter = FeedFilter(None, None, Map.empty)
 }
 case class FeedContext[F[_]](embeddings: Option[Mapping[String, List[String], F]],
                              filter: FeedFilter,

--- a/src/test/scala/com/intenthq/action_processor/integrations/TestDefaults.scala
+++ b/src/test/scala/com/intenthq/action_processor/integrations/TestDefaults.scala
@@ -16,7 +16,7 @@ object TestDefaults {
     levels = 4
   )
 
-  val feedFilter: FeedFilter = FeedFilter(None, None)
+  val feedFilter: FeedFilter = FeedFilter.empty
 
   def feedContext[F[_]]: FeedContext[F] =
     FeedContext[F](None, feedFilter, mapDbSettings, None)


### PR DESCRIPTION
This will allow users of the action processor to partition their queries by any arbitrary value, not just the date and time.

This is a breaking change because I did not provide a default value in the constructor (could be Map.empty if we need one)