### PR TITLE
Update Dependabot configuration to include labels on the GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: 'Chore: '
+    labels:
+      - github_actions
+      - dependencies
+      - chore


### PR DESCRIPTION
This PR updates the Dependabot configuration to include labels on the GitHub Actions.

Links to intenthq/infrastructure#6834